### PR TITLE
core: res: Add GoogleDialer into privacy indicator exemption list

### DIFF
--- a/core/res/custom_res/res/values/pixel_config.xml
+++ b/core/res/custom_res/res/values/pixel_config.xml
@@ -19,6 +19,7 @@
         <item>org.pixelexperience.faceunlock</item>
         <item>co.aospa.sense</item>
         <item>com.google.android.setupwizard</item>
+        <item>com.google.android.dialer</item>
     </string-array>
 
     <!-- Whether to cancel fingerprint operation if not idle -->


### PR DESCRIPTION
It keeps spamming on every dialer launch.
> Please use squash and merge option, so that the commit history doesn't get polluted.